### PR TITLE
[367440] Servicebus and developer queues creation

### DIFF
--- a/Infra/modules/Microsoft.Servicebus/servicebus.bicep
+++ b/Infra/modules/Microsoft.Servicebus/servicebus.bicep
@@ -1,0 +1,13 @@
+@description('Name of the Service Bus namespace')
+param serviceBusNamespaceName string
+
+param location string
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-01-01-preview' = {
+  name: serviceBusNamespaceName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {}
+}

--- a/azure-pipelines/scripts/developer-queues.ps1
+++ b/azure-pipelines/scripts/developer-queues.ps1
@@ -1,0 +1,109 @@
+
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [String]
+    $RESOURCE_GROUP,
+
+    [Parameter()]
+    [String]
+    $NAME_SPACE,
+
+    [Parameter()]
+    [String[]]
+    $developerList,
+
+    [Parameter()]
+    [String]
+    $QUEUE_SIZE,
+
+    [Parameter()]
+    [String]
+    $DUPLICATION_DETECTION,
+
+    [Parameter()]
+    [String]
+    $QUEUE_TTL,
+
+    [Parameter()]
+    [String]
+    $CUSTOM_QUEUE,
+
+    [Parameter()]
+    [String]
+    $DELETE_QUEUE,
+
+    [Parameter()]
+    [String[]]
+    $CUSTOM_QUEUE_NAME_LIST
+)
+
+
+function devQueues ($devList) {
+
+    $developersQueues = $devList.Split(",")
+    Write-Host "List of Developers to create is: $developersQueues"
+
+    foreach ($queueName in $developersQueues) {
+
+        Write-Host " Creating queue for: $queueName"
+
+        if (az servicebus queue list --resource-group $RESOURCE_GROUP --namespace-name $NAME_SPACE --query "[].name" -o tsv | grep $queueName) {
+            Write-Host "The queue for $queueName already exists"
+        }
+        else {
+            az servicebus queue create `
+            --resource-group $RESOURCE_GROUP `
+            --namespace-name $NAME_SPACE `
+            --name $queueName `
+            --max-size $QUEUE_SIZE `
+            --enable-duplicate-detection $DUPLICATION_DETECTION `
+            --default-message-time-to-live $QUEUE_TTL `
+            --enable-session true
+        }
+    }
+}
+
+function createQueue ($CustomQueueName) {
+
+    $newQueues = $CustomQueueName.Split(",")
+    foreach ($Q in $newQueues) {
+        if (az servicebus queue list --resource-group $RESOURCE_GROUP --namespace-name $NAME_SPACE --query "[].name" -o tsv | grep $Q) {
+            Write-Host "The queue for $Q already exists"
+        }
+        else {
+            az servicebus queue create `
+            --resource-group $RESOURCE_GROUP `
+            --namespace-name $NAME_SPACE `
+            --name $Q `
+            --max-size $QUEUE_SIZE `
+            --enable-duplicate-detection $DUPLICATION_DETECTION `
+            --default-message-time-to-live $QUEUE_TTL `
+            --enable-session true
+            write-host "$Q has been created"
+        }
+    }
+}
+
+function deleteQueue ($deleteQueueName) {
+
+    $deleteQueues = $CustomQueueName.Split(",")
+
+    foreach ($Q in $deleteQueues) {
+        az servicebus queue delete --resource-group $RESOURCE_GROUP --namespace-name $NAME_SPACE --name $Q
+        write-host "$Q servicebus queue has been delete"
+    }
+
+
+
+}
+
+if ($CUSTOM_QUEUE -eq "true") {
+    createQueue -CustomQueueName $CUSTOM_QUEUE_NAME_LIST
+}
+elseif ($DELETE_QUEUE -eq "true") {
+    deleteQueue -deleteQueueName $CUSTOM_QUEUE_NAME_LIST
+}
+else {
+    devQueues -devList $developerList
+}

--- a/azure-pipelines/servicebus/developer-queues.yaml
+++ b/azure-pipelines/servicebus/developer-queues.yaml
@@ -1,0 +1,88 @@
+parameters:
+  - name: CustomQueue
+    displayName: "True if you want to create a new queue(s). Multiple queues created by comma seperated list"
+    type: string
+    default: "false"
+    values:
+      - "true"
+      - "false"
+  - name: DeleteQueue
+    displayName: "True if you want to delete a queue(s). Multiple queues deleted by comma seperated list"
+    type: string
+    default: "false"
+    values:
+      - "true"
+      - "false"
+  - name: QueueNameList
+    displayName: "Specify comma seperated queue names here"
+    type: string
+    default: "blank"
+
+trigger: none
+
+schedules:
+  - cron: "0 0 * * 1"
+    displayName: Weekly midnight build.
+    branches:
+      include:
+        - main
+
+name: "DEFRA-STW-Developer-Queues-Creation-CD"
+
+variables:
+  - name: CUSTOM_QUEUE
+    value: ${{ parameters.CustomQueue }}
+  - name: DELETE_QUEUE
+    value: ${{ parameters.DeleteQueue }}
+  - name: CUSTOM_QUEUE_NAME_LIST
+    value: ${{ parameters.QueueNameList }}
+
+resources:
+  repositories:
+    - repository: PipelineCommon
+      name: DEFRA-DEVOPS-COMMON/Defra.Pipeline.Common
+      type: git
+      ref: refs/tags/Release-v6-latest
+
+extends:
+  template: /templates/pipelines/common-scripts-deploy.yaml@PipelineCommon
+  parameters:
+    keyVaultName: $(keyVaultName)
+    keyVaultSecretsFilter: tenantId, subscriptionId
+    forceDeploy: true
+    variableFiles:
+      - /azure-pipelines/vars/common.yaml@self
+      - /azure-pipelines/vars/{environment}.yaml@self
+    regionalVariableFiles:
+      - /azure-pipelines/vars/regional/{environment}-{region}.yaml@self
+    environments:
+      - name: "dev"
+        developmentEnvironment: True
+        azureRegions:
+          isSecondaryRegionDeploymentActive: false
+          primary: NorthEurope
+        tenantId: $(tenantId)
+        tenantName: $(tenantName)
+        subscriptionId: $(subscriptionId)
+        serviceConnection: AZR-STW-DEV1
+        deploymentBranches:
+          - "*"
+    scriptsList:
+      - displayName: Service Bus Queue Creation Script
+        type: AzureCLI
+        azurePowershellUseCore: AzurePowerShell
+        AzureCLIScriptType: pscore
+        scriptPath: azure-pipelines\scripts\developer-queues.ps1
+        filePathsForTransform: 
+          - azure-pipelines\scripts\developer-queues.ps1
+        scriptArguments: >
+          -RESOURCE_GROUP $(serviceBusRGP)
+          -NAME_SPACE $(serviceBusNamespaceName)
+          -developerList $(developerList)
+          -QUEUE_SIZE $(servicebusQueueSize)
+          -DUPLICATION_DETECTION $(duplicationDetection)
+          -QUEUE_TTL $(servicebusQueueTTL)
+          -CUSTOM_QUEUE $(CUSTOM_QUEUE)
+          -DELETE_QUEUE $(DELETE_QUEUE)
+          -CUSTOM_QUEUE_NAME_LIST $(CUSTOM_QUEUE_NAME_LIST)
+        failOnStandardError: false

--- a/azure-pipelines/servicebus/servicebus.bicep
+++ b/azure-pipelines/servicebus/servicebus.bicep
@@ -1,0 +1,11 @@
+param serviceBusNamespaceName string
+param location string = resourceGroup().location
+
+module serviceBus '../../Infra/modules/Microsoft.Servicebus/servicebus.bicep' = {
+  name: serviceBusNamespaceName
+  params: {
+    serviceBusNamespaceName: serviceBusNamespaceName
+    location: location
+  }
+}
+

--- a/azure-pipelines/servicebus/servicebus.parameters.DEV.json
+++ b/azure-pipelines/servicebus/servicebus.parameters.DEV.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serviceBusNamespaceName": {
+            "value": "DEVSTWINFSBS1001"
+        }
+    }
+}

--- a/azure-pipelines/servicebus/servicebus.yaml
+++ b/azure-pipelines/servicebus/servicebus.yaml
@@ -1,0 +1,38 @@
+parameters:
+  - name: deployEnvironment
+    displayName: "Which environment to deploy into?"
+    type: string
+    default: "DEV"
+    values:
+      - "DEV"
+
+trigger: none
+
+variables:
+  - name: deployEnvironment
+    value: ${{ parameters.deployEnvironment }}
+  - ${{ if eq(parameters.deployEnvironment, 'DEV') }}:
+      - group: servicebus-dev
+
+
+steps:
+  - checkout: self
+
+  - task: AzureCLI@2
+    displayName: 'Deploy Bicep file'
+    inputs:
+      azureSubscription: AZR-STW-DEV1
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        # Creating a resource group
+        az group create \
+          --name $(serviceBusRGP) \
+          --location northeurope
+        # Deploying Bicep file
+        az deployment group create \
+          --name $(Build.BuildNumber) \
+          --resource-group $(serviceBusRGP) \
+          --template-file azure-pipelines/servicebus/servicebus.bicep \
+          --parameters azure-pipelines/servicebus/servicebus.parameters.$(deployEnvironment).json \
+          --parameters location='northeurope'

--- a/azure-pipelines/vars/common.yaml
+++ b/azure-pipelines/vars/common.yaml
@@ -1,0 +1,9 @@
+variables:
+
+  tenantName: Defra
+
+  #ServiceBus
+  developerList: "reece.bennett,kamil.mojek,sean.treanor,joshua.higginson"
+  servicebusQueueSize: 2048
+  duplicationDetection: true
+  servicebusQueueTTL: P14D

--- a/azure-pipelines/vars/dev.yaml
+++ b/azure-pipelines/vars/dev.yaml
@@ -1,0 +1,10 @@
+variables:
+
+  serviceConnection: AZR-STW-DEV1
+  keyVaultName: DEVSTWINFVT1001
+
+
+  #Servicebus
+
+  serviceBusNamespaceName: DEVSTWINFSBS1001
+  serviceBusRGP: DEVSTWINFRG1001

--- a/azure-pipelines/vars/regional/common-region/common.yaml
+++ b/azure-pipelines/vars/regional/common-region/common.yaml
@@ -1,0 +1,2 @@
+variables:
+  environment: dev

--- a/azure-pipelines/vars/regional/common-region/dev.yaml
+++ b/azure-pipelines/vars/regional/common-region/dev.yaml
@@ -1,0 +1,2 @@
+variables:
+  environment: dev

--- a/azure-pipelines/vars/regional/dev-northeurope.yaml
+++ b/azure-pipelines/vars/regional/dev-northeurope.yaml
@@ -1,0 +1,3 @@
+variables:
+
+  serviceConnection: AZR-STW-DEV1


### PR DESCRIPTION
- * added developerQueues creation pwsh (creates a queue for each developer, remakes the queues once every week
- * added option to create specific queues on the servicebus, just supply comma separated queue names on the pipeline
- * added option to remove specific queues on the servicebus, same as above.


Done some work with vars files, pipeline yaml and keyvault pull + service connection.